### PR TITLE
Add new useHttp option to module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+## Added
+* new option `authSpecOptions`.  This will get added verbatim to the result of authenticationSpecification function
+
 ## [1.0.0] - 2018-05-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ## Added
-* new option `authSpecOptions`.  This will get added verbatim to the result of authenticationSpecification function
+* new option `authSpecExtension`. Must be an object. This will get added verbatim to the result of authenticationSpecification function
 
 ## [1.0.0] - 2018-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ## Added
-* new option `authSpecExtension`. Must be an object. This will get added verbatim to the result of authenticationSpecification function
+* new option `useHttp`. Must be a boolean. This will get added verbatim to the result of authenticationSpecification function
 
 ## [1.0.0] - 2018-05-22
 

--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ Finally, create a JSON file store.  This should be an array of objects with prop
 | userStoreFilePath | <code>string</code> | path to the JSON file containing the array of username/password objects |
 | options | <code>object</code> | options object |
 | options.tokenExpirationMinutes | <code>integer</code> | minutes until token expires (default 60) |
+| options.authSpecOptions | <code>object</code> | additional key-value data to be return in result of authenticationSpecification function |

--- a/README.md
+++ b/README.md
@@ -38,26 +38,12 @@ Finally, create a JSON file store.  This should be an array of objects with prop
 | userStoreFilePath | <code>string</code> | path to the JSON file containing the array of username/password objects |
 | options | <code>object</code> | options object |
 | options.tokenExpirationMinutes | <code>integer</code> | minutes until token expires (default 60) |
-| options.authSpecExtension | <code>object</code> | additional key-value data to return in result of authenticationSpecification function |
-
-## Extending the authentication-specification
-The method `authenticationSpecification` returns simple information to the caller.  By default, this includes the `name` of the provider that is calling the method and a simple boolean property, `secured`, indicating that authentication/authorization is currently applied to the provider. For certain implementations, it may be important to add additional properties to the result of `authenticationSpecification()` and you can do that by adding the option `authSpecExtension` when configuring the module.  Its value should be an object literal.  For example, this implementation:  
-
-    let auth = require('@koopjs/auth-direct-file')('pass-in-your-secret', `${__dirname}/user-store.json`, { authSpecExtention: { myNewProp: 'hello there' } })
-    koop.register(auth)
-
-would result in the following object being returned from `authenticationSpecification()`:  
-
-    {
-      name: 'my-provider',
-      secured: true,
-      myNewProp: 'hello there'
-    }
+| options.useHttp | <code>boolean</code> | pass the `useHttp` boolean flag as part of the authenticationSpecification function result|
 
 ## Special considerations for use with [koop-ouput-geoservices](https://github.com/koopjs/koop-output-geoservices)
-[koop-ouput-geoservice](https://github.com/koopjs/koop-output-geoservices) geoservices assumes that token-services occur over HTTPS.  For development purposes you may wish to allow authentication to occur of HTTP.  This can be done by extending the `autheticationSpecification` result, as noted above, to include `ssl: false`:
+[koop-ouput-geoservices](https://github.com/koopjs/koop-output-geoservices) assumes that token-services occur over HTTPS.  For development purposes you may wish to allow authentication to occur of HTTP.  This can be done two different ways.  You can add the `useHttp` option when configuring the module, which will be passed on in the result of `autheticationSpecification()` calls.
 
-    let auth = require('@koopjs/auth-direct-file')('pass-in-your-secret', `${__dirname}/user-store.json`, { authSpecExtention: { ssl: false } })
+    let auth = require('@koopjs/auth-direct-file')('pass-in-your-secret', `${__dirname}/user-store.json`, { useHttp: true })
     koop.register(auth)
 
-This addition will inform [koop-ouput-geoservices](https://github.com/koopjs/koop-output-geoservices) to use `http` as the protocol for its definition of the `tokenServicesUrl`.
+Alternatively, you can set an environment variable `KOOP_AUTH_HTTP=true`.  Either of these approaches inform [koop-ouput-geoservices](https://github.com/koopjs/koop-output-geoservices) to use `http` as the protocol of the `tokenServicesUrl`.

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ Finally, create a JSON file store.  This should be an array of objects with prop
 | userStoreFilePath | <code>string</code> | path to the JSON file containing the array of username/password objects |
 | options | <code>object</code> | options object |
 | options.tokenExpirationMinutes | <code>integer</code> | minutes until token expires (default 60) |
-| options.authSpecOptions | <code>object</code> | additional key-value data to be return in result of authenticationSpecification function |
+| options.authSpecExtension | <code>object</code> | additional key-value data to be return in result of authenticationSpecification function |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Finally, create a JSON file store.  This should be an array of objects with prop
 | options.useHttp | <code>boolean</code> | pass the `useHttp` boolean flag as part of the authenticationSpecification function result|
 
 ## Special considerations for use with [koop-ouput-geoservices](https://github.com/koopjs/koop-output-geoservices)
-[koop-ouput-geoservices](https://github.com/koopjs/koop-output-geoservices) assumes that token-services occur over HTTPS.  For development purposes you may wish to allow authentication to occur of HTTP.  This can be done two different ways.  You can add the `useHttp` option when configuring the module, which will be passed on in the result of `autheticationSpecification()` calls.
+[koop-ouput-geoservices](https://github.com/koopjs/koop-output-geoservices) assumes that token-services occur over HTTPS.  For development purposes you may wish to allow authentication to occur of HTTP.  This can be done two different ways.  You can add the `useHttp` option when configuring the module, which will be passed on in the result of `authenticationSpecification()` calls.
 
     let auth = require('@koopjs/auth-direct-file')('pass-in-your-secret', `${__dirname}/user-store.json`, { useHttp: true })
     koop.register(auth)

--- a/README.md
+++ b/README.md
@@ -38,4 +38,26 @@ Finally, create a JSON file store.  This should be an array of objects with prop
 | userStoreFilePath | <code>string</code> | path to the JSON file containing the array of username/password objects |
 | options | <code>object</code> | options object |
 | options.tokenExpirationMinutes | <code>integer</code> | minutes until token expires (default 60) |
-| options.authSpecExtension | <code>object</code> | additional key-value data to be return in result of authenticationSpecification function |
+| options.authSpecExtension | <code>object</code> | additional key-value data to return in result of authenticationSpecification function |
+
+## Extending the authentication-specification
+The method `authenticationSpecification` returns simple information to the caller.  By default, this includes the `name` of the provider that is calling the method and a simple boolean property, `secured`, indicating that authentication/authorization is currently applied to the provider. For certain implementations, it may be important to add additional properties to the result of `authenticationSpecification()` and you can do that by adding the option `authSpecExtension` when configuring the module.  Its value should be an object literal.  For example, this implementation:  
+
+    let auth = require('@koopjs/auth-direct-file')('pass-in-your-secret', `${__dirname}/user-store.json`, { authSpecExtention: { myNewProp: 'hello there' } })
+    koop.register(auth)
+
+would result in the following object being returned from `authenticationSpecification()`:  
+
+    {
+      name: 'my-provider',
+      secured: true,
+      myNewProp: 'hello there'
+    }
+
+## Special considerations for use with [koop-ouput-geoservices](https://github.com/koopjs/koop-output-geoservices)
+[koop-ouput-geoservice](https://github.com/koopjs/koop-output-geoservices) geoservices assumes that token-services occur over HTTPS.  For development purposes you may wish to allow authentication to occur of HTTP.  This can be done by extending the `autheticationSpecification` result, as noted above, to include `ssl: false`:
+
+    let auth = require('@koopjs/auth-direct-file')('pass-in-your-secret', `${__dirname}/user-store.json`, { authSpecExtention: { ssl: false } })
+    koop.register(auth)
+
+This addition will inform [koop-ouput-geoservices](https://github.com/koopjs/koop-output-geoservices) to use `http` as the protocol for its definition of the `tokenServicesUrl`.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/koopjs/koop-auth-direct#readme",
   "dependencies": {
-    "jsonwebtoken": "^8.2.1"
+    "jsonwebtoken": "^8.2.1",
+    "lodash": "^4.17.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "homepage": "https://github.com/koopjs/koop-auth-direct#readme",
   "dependencies": {
-    "jsonwebtoken": "^8.2.1",
-    "lodash": "^4.17.10"
+    "jsonwebtoken": "^8.2.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
 const fs = require('fs')
 const jwt = require('jsonwebtoken')
+const _ = require('lodash')
 const validateCredentials = require('./validate-credentials')
 const TOKEN_EXPIRATION_MINUTES = 60
-let _authSpecOptions
+let _authSpecExtension
 let _tokenExpirationMinutes
 let _secret
 let _userStoreFilePath
@@ -13,7 +14,7 @@ let _userStoreFilePath
  * @param {string}   userStoreFilePath - file path of user store JSON file
  * @param {object}   options
  * @param {integer}  options.tokenExpirationMinutes - number of minutes until token expires
- * @param {boolean}  options.authSpecOptions - additional options to be passed back in result of authenticationSpecification()
+ * @param {boolean}  options.authSpecExtension - additional options to be passed back in result of authenticationSpecification()
  */
 function auth (secret, userStoreFilePath, options = {}) {
   // Throw error if user-store file does not exist
@@ -23,11 +24,12 @@ function auth (secret, userStoreFilePath, options = {}) {
 
   _secret = secret
   _userStoreFilePath = userStoreFilePath
-  if (options.authSpecOptions) {
-    if (options.authSpecOptions.hasOwnProperty('provider')) throw new Error(`"provider" not allow as an authSpecOption key`)
-    if (options.authSpecOptions.hasOwnProperty('secured')) throw new Error(`"secured" not allow as an authSpecOption key`)
+  if (options.authSpecExtension) {
+    if (!_.isPlainObject(options.authSpecExtension)) throw new Error(`"authSpecExtension" must be a plain object`)
+    if (options.authSpecExtension.hasOwnProperty('provider')) throw new Error(`"provider" not allow as an authSpecExtension key`)
+    if (options.authSpecExtension.hasOwnProperty('secured')) throw new Error(`"secured" not allow as an authSpecExtension key`)
   }
-  _authSpecOptions = options.authSpecOptions || {}
+  _authSpecExtension = options.authSpecExtension || {}
 
   //  Ensure token expiration is an integer greater than 5
   if (options.tokenExpirationMinutes && (!Number.isInteger(options.tokenExpirationMinutes) || options.tokenExpirationMinutes < 5)) throw new Error(`"tokenExpirationMinutes" must be an integer >= 5`)
@@ -48,7 +50,7 @@ function auth (secret, userStoreFilePath, options = {}) {
  */
 function getAuthenticationSpecification (providerNamespace) {
   return function authenticationSpecification () {
-    return Object.assign(_authSpecOptions, {
+    return Object.assign(_authSpecExtension, {
       provider: providerNamespace,
       secured: true
     })

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
 const fs = require('fs')
 const jwt = require('jsonwebtoken')
 const validateCredentials = require('./validate-credentials')
-const TOKEN_EXPIRATION_MINTUES = 60
+const TOKEN_EXPIRATION_MINUTES = 60
+const SSL = true
 let _tokenExpirationMinutes
+let _ssl
 let _secret
 let _userStoreFilePath
 
@@ -12,6 +14,7 @@ let _userStoreFilePath
  * @param {string}   userStoreFilePath - file path of user store JSON file
  * @param {object}   options
  * @param {integer}  options.tokenExpirationMinutes - number of minutes until token expires
+ * @param {boolean}  options.ssl - use https as protocol for authentication
  */
 function auth (secret, userStoreFilePath, options = {}) {
   // Throw error if user-store file does not exist
@@ -21,10 +24,14 @@ function auth (secret, userStoreFilePath, options = {}) {
 
   _secret = secret
   _userStoreFilePath = userStoreFilePath
-  _tokenExpirationMinutes = options.tokenExpirationMinutes || TOKEN_EXPIRATION_MINTUES
 
   //  Ensure token expiration is an integer greater than 5
-  if (!Number.isInteger(_tokenExpirationMinutes) || _tokenExpirationMinutes < 5) throw new Error(`"tokenExpirationMinutes" must be an integer >= 5`)
+  if (options.tokenExpirationMinutes && (!Number.isInteger(options.tokenExpirationMinutes) || options.tokenExpirationMinutes < 5)) throw new Error(`"tokenExpirationMinutes" must be an integer >= 5`)
+  //  Ensure ssl option was a boolean
+  if (options.ssl && typeof options.ssl !== 'boolean') throw new Error(`"ssl" option must be a boolean`)
+
+  _tokenExpirationMinutes = options.tokenExpirationMinutes || TOKEN_EXPIRATION_MINUTES
+  _ssl = (options.ssl === false) ? false : SSL
 
   return {
     type: 'auth',
@@ -42,7 +49,8 @@ function getAuthenticationSpecification (providerNamespace) {
   return function authenticationSpecification () {
     return {
       provider: providerNamespace,
-      secured: true
+      secured: true,
+      ssl: _ssl
     }
   }
 }

--- a/test/auth.js
+++ b/test/auth.js
@@ -61,14 +61,24 @@ test('authenticationSpecifiction', t => {
   t.equals(result.provider, providerMock.name)
 })
 
-test('authSpecOptions', t => {
+test('authSpecOptions - useHttp: true', t => {
   t.plan(3)
-  let optionAuth = require('../src')(secret, path.join(__dirname, '/fixtures/user-store.json'), {authSpecExtension: {ssl: false}})
+  let optionAuth = require('../src')(secret, path.join(__dirname, '/fixtures/user-store.json'), {useHttp: true})
   let authenticationSpecification = optionAuth.getAuthenticationSpecification(providerMock.name)
   let result = authenticationSpecification()
   t.equals(result.secured, true)
   t.equals(result.provider, providerMock.name)
-  t.equals(result.ssl, false)
+  t.equals(result.useHttp, true)
+})
+
+test('authSpecOptions - useHttp: false', t => {
+  t.plan(3)
+  let optionAuth = require('../src')(secret, path.join(__dirname, '/fixtures/user-store.json'), {useHttp: false})
+  let authenticationSpecification = optionAuth.getAuthenticationSpecification(providerMock.name)
+  let result = authenticationSpecification()
+  t.equals(result.secured, true)
+  t.equals(result.provider, providerMock.name)
+  t.equals(result.useHttp, false)
 })
 
 test('tokenExpirationMinutes - invalid "tokenExpirationMinutes" setting', t => {
@@ -78,16 +88,9 @@ test('tokenExpirationMinutes - invalid "tokenExpirationMinutes" setting', t => {
   }, /"tokenExpirationMinutes" must be an integer >= 5/)
 })
 
-test('tokenExpirationMinutes - invalid "authSpecExtension.provider" setting', t => {
+test('tokenExpirationMinutes - invalid "useHttp" setting', t => {
   t.plan(1)
   t.throws(function () {
-    require('../src')(secret, path.join(__dirname, '/fixtures/user-store.json'), {authSpecExtension: {provider: 'test'}})
-  }, /"provider" not allow as an authSpecExtension key/)
-})
-
-test('tokenExpirationMinutes - invalid "authSpecExtension.secured" setting', t => {
-  t.plan(1)
-  t.throws(function () {
-    require('../src')(secret, path.join(__dirname, '/fixtures/user-store.json'), {authSpecExtension: {secured: 'test'}})
-  }, /"secured" not allow as an authSpecExtension key/)
+    require('../src')(secret, path.join(__dirname, '/fixtures/user-store.json'), {useHttp: 'string-value'})
+  }, /"useHttp" must be a boolean/)
 })

--- a/test/auth.js
+++ b/test/auth.js
@@ -63,7 +63,7 @@ test('authenticationSpecifiction', t => {
 
 test('authSpecOptions', t => {
   t.plan(3)
-  let optionAuth = require('../src')(secret, path.join(__dirname, '/fixtures/user-store.json'), {authSpecOptions: {ssl: false}})
+  let optionAuth = require('../src')(secret, path.join(__dirname, '/fixtures/user-store.json'), {authSpecExtension: {ssl: false}})
   let authenticationSpecification = optionAuth.getAuthenticationSpecification(providerMock.name)
   let result = authenticationSpecification()
   t.equals(result.secured, true)
@@ -78,16 +78,16 @@ test('tokenExpirationMinutes - invalid "tokenExpirationMinutes" setting', t => {
   }, /"tokenExpirationMinutes" must be an integer >= 5/)
 })
 
-test('tokenExpirationMinutes - invalid "authSpecOptions.provider" setting', t => {
+test('tokenExpirationMinutes - invalid "authSpecExtension.provider" setting', t => {
   t.plan(1)
   t.throws(function () {
-    require('../src')(secret, path.join(__dirname, '/fixtures/user-store.json'), {authSpecOptions: {provider: 'test'}})
-  }, /"provider" not allow as an authSpecOption key/)
+    require('../src')(secret, path.join(__dirname, '/fixtures/user-store.json'), {authSpecExtension: {provider: 'test'}})
+  }, /"provider" not allow as an authSpecExtension key/)
 })
 
-test('tokenExpirationMinutes - invalid "authSpecOptions.secured" setting', t => {
+test('tokenExpirationMinutes - invalid "authSpecExtension.secured" setting', t => {
   t.plan(1)
   t.throws(function () {
-    require('../src')(secret, path.join(__dirname, '/fixtures/user-store.json'), {authSpecOptions: {secured: 'test'}})
-  }, /"secured" not allow as an authSpecOption key/)
+    require('../src')(secret, path.join(__dirname, '/fixtures/user-store.json'), {authSpecExtension: {secured: 'test'}})
+  }, /"secured" not allow as an authSpecExtension key/)
 })

--- a/test/auth.js
+++ b/test/auth.js
@@ -54,11 +54,29 @@ test('authenticate failure', async function (t) {
 })
 
 test('authenticationSpecifiction', t => {
-  t.plan(2)
+  t.plan(3)
   let authenticationSpecification = auth.getAuthenticationSpecification(providerMock.name)
   let result = authenticationSpecification()
   t.equals(result.secured, true)
   t.equals(result.provider, providerMock.name)
+  t.equals(result.ssl, true)
+})
+
+test('ssl - option setting', t => {
+  t.plan(3)
+  let optionAuth = require('../src')(secret, path.join(__dirname, '/fixtures/user-store.json'), {ssl: false})
+  let authenticationSpecification = optionAuth.getAuthenticationSpecification(providerMock.name)
+  let result = authenticationSpecification()
+  t.equals(result.secured, true)
+  t.equals(result.provider, providerMock.name)
+  t.equals(result.ssl, false)
+})
+
+test('ssl - invalid setting', t => {
+  t.plan(1)
+  t.throws(function () {
+    require('../src')(secret, path.join(__dirname, '/fixtures/user-store.json'), {ssl: 'false'})
+  }, /"ssl" option must be a boolean/)
 })
 
 test('tokenExpirationMinutes - invalid setting', t => {

--- a/test/auth.js
+++ b/test/auth.js
@@ -54,17 +54,16 @@ test('authenticate failure', async function (t) {
 })
 
 test('authenticationSpecifiction', t => {
-  t.plan(3)
+  t.plan(2)
   let authenticationSpecification = auth.getAuthenticationSpecification(providerMock.name)
   let result = authenticationSpecification()
   t.equals(result.secured, true)
   t.equals(result.provider, providerMock.name)
-  t.equals(result.ssl, true)
 })
 
-test('ssl - option setting', t => {
+test('authSpecOptions', t => {
   t.plan(3)
-  let optionAuth = require('../src')(secret, path.join(__dirname, '/fixtures/user-store.json'), {ssl: false})
+  let optionAuth = require('../src')(secret, path.join(__dirname, '/fixtures/user-store.json'), {authSpecOptions: {ssl: false}})
   let authenticationSpecification = optionAuth.getAuthenticationSpecification(providerMock.name)
   let result = authenticationSpecification()
   t.equals(result.secured, true)
@@ -72,16 +71,23 @@ test('ssl - option setting', t => {
   t.equals(result.ssl, false)
 })
 
-test('ssl - invalid setting', t => {
-  t.plan(1)
-  t.throws(function () {
-    require('../src')(secret, path.join(__dirname, '/fixtures/user-store.json'), {ssl: 'false'})
-  }, /"ssl" option must be a boolean/)
-})
-
-test('tokenExpirationMinutes - invalid setting', t => {
+test('tokenExpirationMinutes - invalid "tokenExpirationMinutes" setting', t => {
   t.plan(1)
   t.throws(function () {
     require('../src')(secret, path.join(__dirname, '/fixtures/user-store.json'), {tokenExpirationMinutes: -1})
   }, /"tokenExpirationMinutes" must be an integer >= 5/)
+})
+
+test('tokenExpirationMinutes - invalid "authSpecOptions.provider" setting', t => {
+  t.plan(1)
+  t.throws(function () {
+    require('../src')(secret, path.join(__dirname, '/fixtures/user-store.json'), {authSpecOptions: {provider: 'test'}})
+  }, /"provider" not allow as an authSpecOption key/)
+})
+
+test('tokenExpirationMinutes - invalid "authSpecOptions.secured" setting', t => {
+  t.plan(1)
+  t.throws(function () {
+    require('../src')(secret, path.join(__dirname, '/fixtures/user-store.json'), {authSpecOptions: {secured: 'test'}})
+  }, /"secured" not allow as an authSpecOption key/)
 })


### PR DESCRIPTION
Added a `authSpecExtension` option to module.  The option, which must be a plain object, is used to extend the result of function `authenticationSpecification`.