### PR TITLE
Use the Express request object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* `authorize` function argument is now the full Express request object
+* Authorization token may be delivered by query parameter `token` or the `authorization` header
+* `authenticate` function argument is now the full Express request object
+* `authenticate` function rejects if username or password are missing
+* Update koop-output-geoservices peer dependency to 2.0.0
+
 ## [1.2.0] - 2018-06-08
-#### Added
+### Added
 * replaced `getAuthenticationSpecification` with `authenticationSpecification`
 
 ## [1.1.1] - 2018-05-31

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   },
   "peerDependencies": {
     "koop":"^3.7.2",
-    "koop-output-geoservices": "^1.5.2"
+    "koop-output-geoservices": "^2.0.0"
   }
 }


### PR DESCRIPTION
This PR uses the Express request object as the function parameter for the `authenticate` and `authorize` functions in order to work properly with koop-output-geoservices `^2.0.0`.